### PR TITLE
Move MVD definitions to a legacy section.

### DIFF
--- a/source/circuit-description.rst
+++ b/source/circuit-description.rst
@@ -1,8 +1,0 @@
-Circuit definition description
-==============================
-
-.. toctree::
-   :hidden:
-
-   mvd2
-   mvd3

--- a/source/index.rst
+++ b/source/index.rst
@@ -32,9 +32,9 @@ The reference implementation to load data for this extension is provided by `lib
    blueconfig
    blueconfig-projection-example
    circuit_files
-   circuit-description
    recipe
    sonata
    NGV
    faq
+   legacy
 

--- a/source/legacy.rst
+++ b/source/legacy.rst
@@ -1,0 +1,8 @@
+Legacy circuit description
+==========================
+
+.. toctree::
+   :hidden:
+
+   legacy_mvd2
+   legacy_mvd3

--- a/source/legacy.rst
+++ b/source/legacy.rst
@@ -1,4 +1,4 @@
-Legacy circuit description
+Legacy Circuit Description
 ==========================
 
 .. toctree::

--- a/source/legacy_mvd2.rst
+++ b/source/legacy_mvd2.rst
@@ -2,6 +2,10 @@
 
 MVD version 2
 =============
+
+.. warning:: This file format is deprecated and has been superseded by the SONATA
+             :ref:`node_file`.
+
 The circuit.mvd2 file contains metadata regarding the cells in the network and
 minicolumn metadata
 

--- a/source/legacy_mvd3.rst
+++ b/source/legacy_mvd3.rst
@@ -3,6 +3,9 @@
 MVD version 3
 =============
 
+.. warning:: This file format is deprecated and has been superseded by the SONATA
+             :ref:`node_file`.
+
 History
 -------
 
@@ -34,17 +37,17 @@ cell, the values of a set of properties or fields.
 The following is a list of all of the known fields used in the current pipeline
 by different tools:
 
- - position: X, Y, Z, stored as 3 floats. The unit is micrometer.
- - orientation: A *unit* quaternion, X Y Z W stored as 4 floats.
- - etype: electrical type.
- - mtype: morphological type.
- - synapse_class: inhibitory/excitatory.
- - morphology: morphology name (i.e. the `.h5` or `.asc` filename without
-   the extension).
- - exc_mini_frequency: mini-frequency of a cell in response to an incoming excitatory
-   connection, with a value that depends on the receiving cell's layer.
- - inh_mini_frequency: mini-frequency of a cell in response to an incoming inhibitory
-   connection, with a value that is constant across all layers.
+- position: X, Y, Z, stored as 3 floats. The unit is micrometer.
+- orientation: A *unit* quaternion, X Y Z W stored as 4 floats.
+- etype: electrical type.
+- mtype: morphological type.
+- synapse_class: inhibitory/excitatory.
+- morphology: morphology name (i.e. the `.h5` or `.asc` filename without
+  the extension).
+- exc_mini_frequency: mini-frequency of a cell in response to an incoming excitatory
+  connection, with a value that depends on the receiving cell's layer.
+- inh_mini_frequency: mini-frequency of a cell in response to an incoming inhibitory
+  connection, with a value that is constant across all layers.
 
 Additional fields can be added (optionals) as static parameters for the circuit generation.
 These parameters are located under the group `/circuit` (e.g `/circuit/seeds` )

--- a/source/sonata_tech.rst
+++ b/source/sonata_tech.rst
@@ -27,6 +27,7 @@ The name convention for the files outputted from ``circuit-build`` is :
   - ``nodes.h5`` for the node file
   - ``edges.h5`` for the edge file
 
+.. _node_file:
 
 Node File
 ---------


### PR DESCRIPTION
With the current documentation, it seems that MVD2 and MVD3 are still
valid options to store circuits in.  With the agreed move to SONATA, we
should mark them as deprecated, and also move their documentation into a
separate, less prominent section.
