### PR TITLE
Changed 'connection_overrides' to be a list

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -76,5 +76,5 @@ html_show_sourcelink = False
 todo_include_todos = True
 
 # to have a SONATA config version as a global substitution value
-CURRENT_SONATA_CONFIG_VERSION = "2.3"  # update this value as needed
+CURRENT_SONATA_CONFIG_VERSION = "2.4"  # update this value as needed
 rst_epilog = f'.. |CurrentSonataConfigVersion| replace:: "{CURRENT_SONATA_CONFIG_VERSION}"'

--- a/source/sonata_simulation.rst
+++ b/source/sonata_simulation.rst
@@ -488,13 +488,14 @@ connection_overrides
 
 *Optional*.
 
-Collection of dictionaries to adjust the synaptic strength or other properties of edges between two sets of nodes. These are executed in the order they are read from the file. If a set of synapses are affected by multiple connection_overrides because of source and target used, the latter will overwrite any repeated fields set by a former. This is useful when making more general adjustments and then more specific adjustments. Any edges unaffected by any connection_overrides are instantiated as prescribed in the model.
+List of dictionaries to adjust the synaptic strength or other properties of edges between two sets of nodes. These are executed in the order they are read from the file. If a set of synapses are affected by multiple connection_overrides because of source and target used, the latter will overwrite any repeated fields set by a former. This is useful when making more general adjustments and then more specific adjustments. Any edges unaffected by any connection_overrides are instantiated as prescribed in the model.
 
 .. table::
 
    ============================== ========== ============ ==========================================
    Property                       Type       Requirement  Description
    ============================== ========== ============ ==========================================
+   name                           text       Mandatory    Descriptive name for the override.
    source                         text       Mandatory    node_set specifying presynaptic nodes.
    target                         text       Mandatory    node_set specifying postsynaptic nodes.
    weight                         float      Optional     Scalar used to adjust synaptic strength.
@@ -509,18 +510,21 @@ Collection of dictionaries to adjust the synaptic strength or other properties o
 
 example::
 
-  "connection_overrides": {
-       "weaken_excitation": {
+  "connection_overrides": [
+       {
+            "name": "weaken_excitation"
             "source": "Excitatory",
             "target": "Mosaic,
             "weight": 0.75,
             "spont_minis": 0.04
        },
-       "deactivate_short_term_plasticity": {
+       {
+            "name": "deactivate_short_term_plasticity",
             "source": "Mosaic",
             "target": "Mosaic",
             "synapse_configure": "%s.Fac = 0 %s.Dep = 0"
-  }
+       }
+  ]
 
 metadata
 ---------
@@ -535,7 +539,7 @@ example::
 
 beta_features
 -------------
-This section is reserved for variables that are used for developing a new feature of the simulation. Once the feature goes in production, the variables should be moved to a proper section in the simulation configuration file. 
+This section is reserved for variables that are used for developing a new feature of the simulation. Once the feature goes in production, the variables should be moved to a proper section in the simulation configuration file.
 
 example::
 

--- a/source/sonata_version_history.rst
+++ b/source/sonata_version_history.rst
@@ -6,6 +6,12 @@ SONATA Version History
 The version of the configuration is shared by both simulation and circuit configuration.
 This listing keeps track of the main changes between versions that could be interesting for the developers.
 
+2.4
+---
+- SONATA Simulation Configuration file
+
+  - Changed `connection_overrides` to be a `list` instead of a `dict`
+
 2.3
 ---
 - Technical Description


### PR DESCRIPTION
This is an implementation ignorant way to ensure `connection_overrides` are always kept in order when read from a file.

Closes #22 