### PR TITLE
add missing reversal property of shotnoise family #18

### DIFF
--- a/source/sonata_simulation.rst
+++ b/source/sonata_simulation.rst
@@ -364,6 +364,7 @@ Note: fields marked Mandatory* depend on which shot_noise version is selected.
    sd_percent                     float      Mandatory*   For relative_shot_noise, signal std dev as percentage of a cell's threshold current (current_clamp) or inverse input resistance (conductance).
    mean                           float      Mandatory*   For absolute_shot_noise, signal mean in nA (current_clamp) or uS (conductance).
    sigma                          float      Mandatory*   For absolute_shot_noise, signal std dev in nA (current_clamp) or uS (conductance).
+   reversal                       float      Optional     Reversal potential for conductance injection in mV. Default is 0.
    dt                             float      Optional     Timestep of generated signal in ms. Default is 0.25 ms.
    random_seed                    integer    Optional     Override the random seed (to introduce correlations between cells).
    ============================== ========== ============ ==========================================


### PR DESCRIPTION
`reversal` is a property of Conductance mode stimuli. It applies to both shot_noise and ornstein families.
It was missing in the shotnoise property table.

It's usage in shotnoise:
* https://github.com/BlueBrain/neurodamus/blob/4b8fd7976721a1542a0fd68f17c5c33898cedcb5/neurodamus/stimulus_manager.py#L270
* https://github.com/BlueBrain/BlueCelluLab/blob/b234c9c69156108aef4fba6dc40407aadf42b85e/bluecellulab/stimuli.py#L348