### PR TITLE
Replace 'electrical_synapse' with 'electrical'

### DIFF
--- a/source/sonata_tech.rst
+++ b/source/sonata_tech.rst
@@ -358,9 +358,9 @@ This type of connectivity happens between astrocytes. The properties are similar
 ``source_node_id`` and ``target_node_id`` datasets have an HDF5 attribute of type string named ``node_population`` defining the source and target node population name respectively.
 
 
-Fields for electrical_synapse connection type edges
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-Connection type is ``electrical_synapse``. Used for gap junctions between neurons
+Fields for electrical connection type edges
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Connection type is ``electrical``. Used for gap junctions between neurons
 
 .. table::
 


### PR DESCRIPTION
Noticed the `electrical_synapse` was still used in `sonata_tech.rst`.

Also, `electrical_synapse` is still used in `use_case_5`. I've updated the `sonata-generator`, so this issue should be fixed on re-run of the generator. Or we can just set it manually in the use cases.