### PR TITLE
FUNCZ-349 Define a JSON/YAML variant of the recipe

### DIFF
--- a/source/legacy.rst
+++ b/source/legacy.rst
@@ -4,5 +4,6 @@ Legacy Circuit Description
 .. toctree::
    :hidden:
 
+   legacy_xml
    legacy_mvd2
    legacy_mvd3

--- a/source/legacy_xml.rst
+++ b/source/legacy_xml.rst
@@ -1,0 +1,373 @@
+.. _recipe_xml:
+
+XML Recipe
+==========
+
+.. highlight:: xml
+
+This document should specify all parameters required to generate the
+connectome of a circuit.
+
+File Format
+-----------
+
+The recipe is specified in XML, and normally stored in a directory named
+`bioname`.  Customarily, the recipe is split into two files:
+
+- `builderRecipeAllPathways.xml`
+- `builderConnectivityRecipeAllPathways.xml`
+
+The latter is usually included in the former via the entity
+``&connectivityRecipe`` and describes the connectivity sampling contained
+in `ConnectionRules`_.
+
+Components
+----------
+
+Seeds
+~~~~~
+
+Part of the connectome building uses statistical sampling, with random
+numbers seeded by the following optional property::
+
+    <Seeds recipeSeed="837632" columnSeed="2906729" synapseSeed="4236279"/>
+
+Where the possible attributes are:
+
+- ``recipeSeed``, with a default of 0. Not used.
+- ``columnSeed``, with a default of 0. Not used.
+- ``synapseSeed``, with a default of 0. Used to sample reduce and cut
+  survival and synapse properties.
+
+InterBoutonInterval
+~~~~~~~~~~~~~~~~~~~
+
+The `InterBoutonInterval` is used to re-distribute touches in a more
+physical way. A typical specification::
+
+    <InterBoutonInterval minDistance="5.0" maxDistance="7.0" regionGap="5.0"/>
+
+All distances are specified in μm.
+
+Following touch detection, `TouchDetector` groups touches into regions
+along a pre-synaptic branch - any two touches closer than ``regionGap``
+will be grouped into a region. New touches will be created on the
+pre-synaptic branch, spaced between ``minDistance`` and ``maxDistance``
+apart. `TouchDetector` will assign the post-synaptic side of the new
+touches based on the previously detected ones.
+
+Thus the parameters are:
+
+- ``minDistance``: minimum distance between two synapses
+- ``maxDistance``: maximum distance between two synapses in a `touch
+  region`
+- ``regionGap``: the minimum distance between two areas designated as
+  `touch regions`.
+
+StructuralSpineLengths
+~~~~~~~~~~~~~~~~~~~~~~
+
+The `StructuralSpineLengths` group is used to determine the initial
+*maximum* distance for spines, measured in µm.
+`TouchDetector` will use these attributes to enlarge the radius of the
+cylindrical representation of branches identified as dendrites.
+Touches will then be generated along the intersecting parts of cylinders
+from different cells.
+
+To specify the spine length allowed for a morphological type, use the
+following form:
+::
+
+      <StructuralSpineLengths>
+          <rule mType="L6_CHC" spineLength="2.5"/>
+      </StructuralSpineLengths>
+
+.. note::
+   The legacy format contained more information and may require pruning.
+   The following structure is also acceptable:
+   ::
+
+      <NeuronTypes>
+          <StructuralType id="L6_CHC" spineLength="2.5"/>
+      </NeuronTypes>
+
+   Where the value of ``id`` identifies the morphology type to be
+   associated with the spine length.
+
+.. warning::
+   No pattern expansion will be performed for this part of the recipe.
+   One rule per `mtype` present in the circuit is required.
+
+InitialBoutonInterval
+~~~~~~~~~~~~~~~~~~~~~
+
+An *optional* XML attribute that specifies the minimum distance in μm that a
+synapse needs to have from the soma. It takes the following form::
+
+    <InitialBoutonInterval inhibitorySynapsesDistance="5.0" excitatorySynapsesDistance="25.0" />
+
+The attributes are defined as follows:
+
+- ``inhibitorySynapsesDistance`` the minimum distance for a synapse for
+  post-synaptic inhibitory cells (default value: 5.0 μm)
+- ``excitatorySynapsesDistance`` the minimum distance for a synapse for
+  post-synaptic excitatory cells (default value: 5.0 μm)
+
+
+TouchRules
+~~~~~~~~~~
+
+The `TouchRules` create a filter to refine the touch space used by
+`TouchDetector`. They take the following form::
+
+    <TouchRules>
+        <touchRule fromMType="*PC" toMType="*" fromBranchType="*" toBranchType="soma" />
+        <touchRule fromMType="*PC" toMType="*" fromBranchType="*" toBranchType="dendrite" />
+    </TouchRules>
+
+where ``*`` denotes a wildcard to match anything. In this example, touches
+are allowed between all layers, but only originating from cells with
+`mtype` ending in ``PC``. The former rule matches all synapses with a soma
+on the post-synaptic side, while the latter matches with a dendrite on the
+post-synaptic side.
+
+Allowed parameters:
+
+- ``fromMType`` the `mtype` of the pre-synaptic cell
+- ``toMType`` the `mtype` of the post-synaptic cell
+- ``fromBranchType`` the classification of the pre-synaptic branch. May be one of
+  the following:
+  - ``*`` to match all branches
+  - ``soma`` to match the soma
+  - ``dendrite`` to match all dendrites
+  - ``basal`` for basal dendrites
+  - ``apical`` for apical dendrites
+- ``toBranchType`` the classification of the post-synaptic branch. May
+  also be referred to as ``type``, for backwards compatibility.
+
+ConnectionRules
+~~~~~~~~~~~~~~~
+
+These rules determine the distribution of synapses. They may take the
+following form::
+
+    <ConnectionRules>
+      <rule fromMType="L1_NGC-DA" toMType="*" bouton_reduction_factor= "0.114" active_fraction= "0.50" cv_syns_connection= "0.25" />
+      <rule fromMType="L1_HAC" toMType="L1_DAC" bouton_reduction_factor= "0.13" active_fraction= "0.50" cv_syns_connection= "0.25" />
+    </ConnectionRules>
+
+.. note::
+   In older recipes, the rules take the form of:
+   ::
+
+      <mTypeRule from="L1_HAC" to="L1_DAC" />
+
+   which will be translated into:
+   ::
+
+      <rule fromMType="L1_HAC" toMType="L1_DAC" />
+
+   automatically.
+
+Every rule can be used to select a subset of connections using attributes
+with the prefixes:
+
+- ``from`` for the pre-synaptic matching requirement
+- ``to`` for the post-synaptic matching requirement
+
+And the following stems:
+
+- ``MType`` to filter by the `mtype` column of the node file(s)
+- ``EType`` to filter by the `etype` column of the node file(s)
+- ``SClass`` to filter by the synaptic classification of the cell
+  (customarily either ``EXC`` or ``INH``)
+- ``Region`` to filter by the `region` column of the node file(s)
+
+The order of the rules matters, later rules may override earlier ones if
+they are at least as specific as the earlier ones.
+I.e., the number of wildcards matching all of an attribute needs to be less
+or equal the rule to be overwritten.
+For example, ``<rule fromMType="bar" …/>`` will be superseded by ``<rule
+fromMType="b*" …?>`` as the constraints are similar, but it will not be
+replaced by ``<rule fromMType="*" …/>``, as that one is broader.
+
+In addition to the selection attributes, exactly one set of constraints have to
+be used:
+
+- ``mean_syns_connection``, ``stdev_syns_connection``, and ``active_fraction``
+- ``bouton_reduction_factor``, ``cv_syns_connection``, and ``active_fraction``
+- ``bouton_reduction_factor``, ``cv_syns_connection``, and ``mean_syns_connection``
+- ``bouton_reduction_factor``, ``cv_syns_connection``, and ``probability``
+- ``bouton_reduction_factor``, ``pMu_A``, and ``p_A``
+
+Where the constraints signify:
+
+.. _active_fraction:
+
+- ``active_fraction``, the fraction of synapses to be removed in the third pruning step
+
+.. _bouton_reduction_factor:
+
+- ``bouton_reduction_factor``, the fraction of synapses to be removed in all three pruning steps
+
+.. _cv_syns_connection:
+
+- ``cv_syns_connection``, the target value for the coefficient of variation of the distribution of synapses per connection distribution of synapses per connections
+
+.. _mean_syns_connection:
+
+- ``mean_syns_connection``, the target value for the mean of the distribution of synapses per connections
+
+.. _p_A:
+
+- ``p_A``, the reduction factor
+
+.. _pMu_A:
+
+- ``pMu_A``, used as input to the survival rate
+
+.. _probability:
+
+- ``probability``, the target connection probability. To be deprecated.
+
+.. _stdev_syns_connection:
+
+- ``stdev_syns_connection``, the target value for the standard deviation of the distribution of synapses per connection
+
+SynapsesProperties
+~~~~~~~~~~~~~~~~~~
+
+The list of `SynapsesProperties` is used to determine which property
+classification is assigned to synapses. It takes the form::
+
+    <SynapsesProperties>
+        <synapse fromSClass="EXC" toSClass="EXC" type="E2" axonalConductionVelocity="0" />
+        <synapse fromSClass="INH" toSClass="INH" type="I2" />
+        <synapse fromSClass="EXC" toMType="L*_ChC" type="E2_PT" />
+        <synapse fromMType="L6_MC" toMType="L6_IPC" toEType="*" type="I1_L6_MC-L6_IPC" />
+    </SynapsesProperties>
+
+Each element within the list of `SynapsesProperties` selects a connection
+given by source and target cell selection criteria. Multiple selections are
+possible:
+
+- ``fromSClass`` to select the pre-synaptic cell class
+- ``toSClass`` to select the post-synaptic cell class
+- ``fromMType`` to select the pre-synaptic `mtype` type
+- ``toMType`` to select the post-synaptic `mtype` type
+- ``fromEType`` to select the pre-synaptic `etype` type
+- ``toEType`` to select the post-synaptic `etype` type
+
+In case selections overlap, the last specified assignment takes precedence.
+To assign synapse properties, the classification field needs to be set:
+
+- ``type`` a name that will be referenced by the
+  `SynapsesClassification`_.
+
+  .. note::
+
+     The type has to start with either ``E`` for excitatory connections or
+     ``I`` for inhibitory connections.
+
+Two optional attributes may be set:
+
+- ``neuralTransmitterReleaseDelay`` with a default of 0.1 ms
+- ``axonalConductionVelocity`` with a default of 300 μm/ms
+
+These two attributes may also be present in the ``SynapsesProperties``
+element, setting default values for all ``synapse`` elements::
+
+    <SynapsesProperties neuralTransmitterReleaseDelay="10.5" axonalConductionVelocity="123.0">
+
+.. _recipe_properties:
+
+SynapsesClassification
+~~~~~~~~~~~~~~~~~~~~~~
+
+Once a classification is assigned to connections, properties are assigned
+to connections by using the `SynapsesClassification` section::
+
+    <SynapsesClassification>
+      <class id="E2"  gsyn="0.792" gsynSD="0.528" nsyn="5.00" nsynSD="2.00" dtc="1.74" dtcSD="0.18" u="0.50" uSD="0.02" d="671" dSD="17" f="017" fSD="5" nrrp="1" />
+    </SynapsesClassification>
+
+Here, the ``id`` field has to match a ``type`` value of the
+`SynapsesProperties`. The properties are assigned using the following
+random number distributions, using a mean `m` and standard deviation `sd`:
+
+- A Gamma-distribution, with shape parameter equal to `m² / sd²`, and
+  scale parameter equal to `sd² / m`.
+- A truncated Normal-distribution, where values are redrawn until they are
+  both positive and within the range of `m±sd`.
+- A Poisson-distribution using only `m`.
+
+The same drawn number is reused for all synapses within the same source to
+target cell connection.
+
+The following properties are supported, with the mean specified by the
+property name, and the standard deviation by appending ``SD`` to the
+property name:
+
+- `gsyn`, the peak conductance (in nS) for a single synaptic contact, following a Gamma distribution
+- `d`, time constant (in ms) for recovery from depression, following a Gamma distribution
+- `f`, time constant (in ms) for recovery from facilitation, following a Gamma distribution
+- `u`, utilization of synaptic efficacy, following a truncated Normal distribution
+- `dtc`, decay time constant (in ms), following a truncated Normal distribution
+- `nrrp`, number of vesicles in readily releasable pool, following a Poisson distribution
+
+Truncated Normal distributions are limited to the central value ±σ and are
+re-rolled until positive values has been obtained.
+
+Two optional attributes can be specified, where each attribute will have to
+be given for all `SynapsesClassification` elements:
+
+- `gsynSRSF`, the scale factor for the conductance; `SRSF`: 'synaptic receptor scaling factor'
+- `uHillCoefficient`, a coefficient describing the scaling of `u` to be
+  done by the simulator:
+
+  .. math::
+
+     u_\text{final} = u \cdot y \cdot \frac{ca^4}{u_\text{Hill}^4 + ca^4}
+
+  where :math:`ca` denotes the simulated calcium concentration in
+  millimolar and :math:`y` a scalar such that at
+  :math:`ca = 2.0:\ u_\text{final} = u`. (Markram et al., 2015)
+
+These attributes will be copied for each synapse corresponding to its
+classification.  If they are not specified, no corresponding columns will
+be created in the output.
+
+SynapsesReposition
+~~~~~~~~~~~~~~~~~~
+
+The `SynapsesReposition` section allows to shift the post-synaptic side of
+touches, e.g., for chandelier cells from the soma to the first axon
+section::
+
+    <SynapsesReposition>
+        <shift fromMType="L*_CHC" toMType="*" type="AIS"/>
+        <shift fromMType="SP_AA" toMType="*" type="AIS"/>
+    </SynapsesReposition>
+
+Allowed properties are:
+
+- ``fromMType`` to select the pre-synaptic cell `mtype`
+- ``toMType`` to select the post-synaptic cell `mtype`
+- ``type`` for the kind of shift. Currently only ``AIS`` for shifts to the
+  first axon section from the soma is supported.
+
+Consumers and invocation order
+------------------------------
+
+- TouchDetector. Uses the following parts:
+   - `StructuralSpineLengths`_
+   - `InterBoutonInterval`_
+- Spykfunc. Uses the following parts:
+   - `Seeds`_
+   - `InitialBoutonInterval`_, used by the `BoutonDistance` filter
+   - `TouchRules`_, used by the similarly named filter (functional execution only)
+   - `ConnectionRules`_, used by the filter `ReduceAndCut` (functional execution only)
+   - `SynapsesProperties`_, used to assign synapses classification
+   - `SynapsesClassification`_, used to assign synapses properties
+   - `SynapsesReposition`_, used to shift post-synaptic segments away from
+     the soma

--- a/source/recipe.rst
+++ b/source/recipe.rst
@@ -242,17 +242,17 @@ property name:
    ==================================== =========== ===
    Property                             Requirement Description
    ==================================== =========== ===
-   ``conductance``                      Mandatory   The peak conductance (in nS) for a single synaptic contact, following a Gamma distribution.
+   ``conductance_mu``                   Mandatory   The central value for the peak conductance (in nS) for a single synaptic contact, following a Gamma distribution.
    ``conductance_sd``                   Mandatory   Standard deviation of ``conductance``.
-   ``depression_time``                  Mandatory   Time constant (in ms) for recovery from depression, following a Gamma distribution.
+   ``depression_time_mu``               Mandatory   Central value for the time constant (in ms) for recovery from depression, following a Gamma distribution.
    ``depression_time_sd``               Mandatory   Standard deviation of ``depression_time``.
-   ``facilitation_time``                Mandatory   Time constant (in ms) for recovery from facilitation, following a Gamma distribution.
+   ``facilitation_time_mu``             Mandatory   Central value for the time constant (in ms) for recovery from facilitation, following a Gamma distribution.
    ``facilitation_time_sd``             Mandatory   Standard deviation of ``f``.
-   ``u_syn``                            Mandatory   Utilization of synaptic efficacy, following a truncated Normal distribution.
+   ``u_syn_mu``                         Mandatory   Central value for the utilization of synaptic efficacy, following a truncated Normal distribution.
    ``u_syn_sd``                         Mandatory   Standard deviation of ``u``.
-   ``decay_time``                       Mandatory   Decay time constant (in ms), following a truncated Normal distribution.
+   ``decay_time_mu``                    Mandatory   Central value for the decay time constant (in ms), following a truncated Normal distribution.
    ``decay_time_sd``                    Mandatory   Standard deviation of ``dtc``.
-   ``n_rrp_vesicles``                   Mandatory   Number of vesicles in readily releasable pool, following a Poisson distribution.
+   ``n_rrp_vesicles_mu``                Mandatory   Central value for the number of vesicles in readily releasable pool, following a Poisson distribution.
 
    ``conductance_scale_factor``         Optional    The scale factor for the conductance; `SRSF`: 'synaptic receptor scaling factor'.
    ``u_hill_coefficient``               Optional    A coefficient describing the scaling of `u` to be done by the simulator.

--- a/source/recipe.rst
+++ b/source/recipe.rst
@@ -56,6 +56,12 @@ referred to with a ``_i`` suffix and stored as numerical values corresponding to
 of the attribute value in the `@library` field of the node files.  Wildcards are no longer
 allowed, but a numerical value of ``-1`` may be used to match all possible values.
 
+.. warning::
+
+   Storing recipe components in DataFrames ties the recipe strongly to one circuit.  Only
+   if the order in the used `@library` fields matches exactly may the recipe be reused
+   for a different circuit.
+
 Given MType values of ``L1_PYR``, ``L2_FOO``, ``L6_SPAM``, ``L6_HAM``, ``L6_EGGS``, and
 region values of ``BLARGH``, ``SPYR``, the above rule then turns into:
 
@@ -69,30 +75,26 @@ region values of ``BLARGH``, ``SPYR``, the above rule then turns into:
    5           -1           0           1
    =========== ============ =========== ============
 
-Components
-----------
+Generic Components
+------------------
 
-``bouton_distances``
-^^^^^^^^^^^^^^^^^^^^
+``version``
+^^^^^^^^^^^
 
-*Optional*, used by Functionalizer.
+*Required*.
 
-Minimum distances for synapses, as measured along the branch length, starting at the soma.
-Synapses with less than the specified distance will be removed by Functionalizer.
+An integer representing the current version of the recipe.  This document describes
+version 1.
 
-.. table::
+Components specific to TouchDetector
+------------------------------------
 
-   =============================== =========== ===
-   Property                        Requirement Description
-   =============================== =========== ===
-   ``excitatory_synapse_distance`` Optional    The minimum distance from the soma for a synapse of post-synaptic excitatory cells in µm. Defaults to 5µm.
-   ``inhibitory_synapse_distance`` Optional    The minimum distance from the soma for a synapse of post-synaptic inhibitory cells in µm. Defaults to 25µm.
-   =============================== =========== ===
+Both components are *required* when running TouchDetector.
 
 ``bouton_interval``
 ^^^^^^^^^^^^^^^^^^^
 
-*Required*, used by TouchDetector.
+*Required*.
 
 Distances used when transforming touch regions into synapse candidates.
 
@@ -106,8 +108,52 @@ Distances used when transforming touch regions into synapse candidates.
    ``region_gap``                  Mandatory   The maximum distance between two touch regions at which they are merged in µm.
    =============================== =========== ===
 
+``structural_spine_lengths``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+*Required*.
+
+A list that specified how long the spines for certain MTypes may be. Requires that all
+MTypes have a spine length assigned. Each item of the list must have the following
+properties:
+
+.. table::
+
+   =============================== =========== ===
+   Property                        Requirement Description
+   =============================== =========== ===
+   ``mtype``                       Mandatory   The MType to apply the spine length to.
+   ``spine_length``                Mandatory   Maxiumum spine length, in µm.
+   =============================== =========== ===
+
+Components specific to Functionalizer
+-------------------------------------
+
+Components used by Functionalizer may only be required when the corresponding filter is
+used. I.e., if only the `SynapseProperties` filter is used, only the
+``synapse_properties`` part of the recipe is required.
+
+``bouton_distances``
+^^^^^^^^^^^^^^^^^^^^
+
+*Optional*.
+
+Minimum distances for synapses, as measured along the branch length, starting at the soma.
+Synapses with less than the specified distance will be removed by Functionalizer.
+
+.. table::
+
+   =============================== =========== ===
+   Property                        Requirement Description
+   =============================== =========== ===
+   ``excitatory_synapse_distance`` Optional    The minimum distance from the soma for a synapse of post-synaptic excitatory cells in µm. Defaults to 5µm.
+   ``inhibitory_synapse_distance`` Optional    The minimum distance from the soma for a synapse of post-synaptic inhibitory cells in µm. Defaults to 25µm.
+   =============================== =========== ===
+
 ``connection_rules``
 ^^^^^^^^^^^^^^^^^^^^
+
+*Required*.
 
 A list of rules that are used to determine how synapse distributions are calculated for
 pathways, and used to reduce the structural connectome to a functional one.
@@ -141,7 +187,7 @@ Where the parameters signify:
 ``gap_junction_properties``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-*Optional*, used by Functionalizer.
+*Optional*.
 
 A global default setting for the conductance produced by Functionalizer.
 
@@ -156,33 +202,15 @@ A global default setting for the conductance produced by Functionalizer.
 ``seed``
 ^^^^^^^^
 
-*Optional*, used by Functionalizer.
+*Optional*.
 
 One of the random number seeds to be used when drawing distributions to cut synapses or
 determine properties.
 
-``structural_spine_lengths``
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-*Required*, used by TouchDetector.
-
-A list that specified how long the spines for certain MTypes may be. Requires that all
-MTypes have a spine length assigned. Each item of the list must have the following
-properties:
-
-.. table::
-
-   =============================== =========== ===
-   Property                        Requirement Description
-   =============================== =========== ===
-   ``mtype``                       Mandatory   The MType to apply the spine length to.
-   ``spine_length``                Mandatory   Maxiumum spine length, in µm.
-   =============================== =========== ===
-
 ``synapse_properties``
 ^^^^^^^^^^^^^^^^^^^^^^
 
-*Optional*, used by Functionalizer.
+*Required*.
 
 Settings to generate synaptic properties for appositions.  Each apposition is classified
 by rules and synaptic properties are generated per cell-cell connection following the
@@ -277,6 +305,8 @@ be created in the output.
 ``synapse_reposition``
 ^^^^^^^^^^^^^^^^^^^^^^
 
+*Required*.
+
 .. table::
 
    =============================== =========== ===
@@ -290,7 +320,7 @@ be created in the output.
 ``touch_rules``
 ^^^^^^^^^^^^^^^
 
-*Optional*, used by Functionalizer.
+*Required*.
 
 Determines which touches are allowed, depending on source and target node population
 MType, as well the section type on either the source or target side of the touch.
@@ -313,7 +343,7 @@ both ``apical`` and ``basal`` types.
 ``touch_reduction``
 ^^^^^^^^^^^^^^^^^^^
 
-*Optional*, used by Functionalizer.
+*Required*.
 
 Used to cut touches according to a flat survival rate set by the user.  Affects all
 touches the same way.

--- a/source/recipe.rst
+++ b/source/recipe.rst
@@ -28,7 +28,7 @@ example or a TouchDetector configuration may look like:
 Generic pathway selection
 -------------------------
 
-Some of the recipe rules may apply only to certain "pathways".  These rules select the
+One can create rules that only apply to certain ``pathways``.
 synapses they apply to by restricting attributes of source and target node populations.
 As such, the rules have properties that are prefixed with `src_` to match attributes from
 the source node population, and likewise prefixed with `dst_` to match target node

--- a/source/recipe.rst
+++ b/source/recipe.rst
@@ -126,7 +126,7 @@ A list of rules that are used to determine how synapse distributions are calcula
 pathways, and used to reduce the structural connectome to a functional one.
 
 Each rule may have properties corresponding to :ref:`selection`. In addition to the
-selection attributes, exactly one set of constraints have to be used:
+selection attributes, exactly one set of parameters have to be used:
 
 - ``mean_syns_connection``, ``stdev_syns_connection``, and ``active_fraction``
 - ``bouton_reduction_factor``, ``cv_syns_connection``, and ``active_fraction``
@@ -134,12 +134,12 @@ selection attributes, exactly one set of constraints have to be used:
 - ``bouton_reduction_factor``, ``cv_syns_connection``, and ``probability``
 - ``bouton_reduction_factor``, ``pMu_A``, and ``p_A``
 
-Where the constraints signify:
+Where the parameters signify:
 
 .. table::
 
    =============================== ===
-   Property                        Description
+   Parameter                       Description
    =============================== ===
    ``active_fraction``             The fraction of synapses to be removed in the third pruning step.
    ``bouton_reduction_factor``     The fraction of synapses to be removed in all three pruning steps.
@@ -197,25 +197,40 @@ properties:
 
 *Optional*, used by Functionalizer.
 
+Settings to generate synaptic properties for appositions.  Each apposition is classified
+by rules and synaptic properties are generated per cell-cell connection following the
+parameters of the property configuration.
+
+.. table::
+
+   =============================== =========== ===
+   Property                        Requirement Description
+   =============================== =========== ===
+   ``rules``                       Mandatory   Rules to classify synapses
+   ``properties``                  Mandatory   Maxiumum spine length, in µm.
+   =============================== =========== ===
+
 ``rules``
 ~~~~~~~~~
 
-- ``type`` a name that will be referenced by the
-  SynapsesClassification.
+Each rule may have properties corresponding to :ref:`selection`. In addition to the
+selection attributes, the following parameters may be present:
 
-  .. note::
+.. table::
 
-     The type has to start with either ``E`` for excitatory connections or
-     ``I`` for inhibitory connections.
-
-- ``neuralTransmitterReleaseDelay`` with a default of 0.1 ms
-- ``axonalConductionVelocity`` with a default of 300 μm/ms
+   ==================================== =========== ===
+   Property                             Requirement Description
+   ==================================== =========== ===
+   ``type``                             Mandatory   A name that will be referenced by ``properties``.  It has to start with either ``E`` for excitatory connections or ``I`` for inhibitory connections.
+   ``neural_transmitter_release_delay`` Optional    Defaults to 0.1 ms
+   ``axonal_conduction_velocity``       Optional    Defaults to 300 μm/ms
+   ==================================== =========== ===
 
 ``properties``
 ~~~~~~~~~~~~~~
 
-Here, the ``id`` field has to match a ``type`` value of the
-SynapsesProperties. The properties are assigned using the following
+Here, the ``type`` field has to match a ``type`` value of the
+``rules``. The properties are assigned using the following
 random number distributions, using a mean `m` and standard deviation `sd`:
 
 - A Gamma-distribution, with shape parameter equal to `m² / sd²`, and
@@ -231,30 +246,38 @@ The following properties are supported, with the mean specified by the
 property name, and the standard deviation by appending ``SD`` to the
 property name:
 
-- `gsyn`, the peak conductance (in nS) for a single synaptic contact, following a Gamma distribution
-- `d`, time constant (in ms) for recovery from depression, following a Gamma distribution
-- `f`, time constant (in ms) for recovery from facilitation, following a Gamma distribution
-- `u`, utilization of synaptic efficacy, following a truncated Normal distribution
-- `dtc`, decay time constant (in ms), following a truncated Normal distribution
-- `nrrp`, number of vesicles in readily releasable pool, following a Poisson distribution
+.. table::
+
+   ==================================== =========== ===
+   Property                             Requirement Description
+   ==================================== =========== ===
+   ``gsyn``                             Mandatory   The peak conductance (in nS) for a single synaptic contact, following a Gamma distribution.
+   ``gsyn_sd``                          Mandatory   Standard deviation of ``gsyn``.
+   ``d``                                Mandatory   Time constant (in ms) for recovery from depression, following a Gamma distribution.
+   ``d_sd``                             Mandatory   Standard deviation of ``d``.
+   ``f``                                Mandatory   Time constant (in ms) for recovery from facilitation, following a Gamma distribution.
+   ``f_sd``                             Mandatory   Standard deviation of ``f``.
+   ``u``                                Mandatory   Utilization of synaptic efficacy, following a truncated Normal distribution.
+   ``u_sd``                             Mandatory   Standard deviation of ``u``.
+   ``dtc``                              Mandatory   Decay time constant (in ms), following a truncated Normal distribution.
+   ``dtc_sd``                           Mandatory   Standard deviation of ``dtc``.
+   ``nrrp``                             Mandatory   Number of vesicles in readily releasable pool, following a Poisson distribution.
+
+   ``gsyn_srsf``                        Optional    The scale factor for the conductance; `SRSF`: 'synaptic receptor scaling factor'.
+   ``u_hill_coefficient``               Optional    A coefficient describing the scaling of `u` to be done by the simulator.
+   ==================================== =========== ===
 
 Truncated Normal distributions are limited to the central value ±σ and are
 re-rolled until positive values has been obtained.
 
-Two optional attributes can be specified, where each attribute will have to
-be given for all `SynapsesClassification` elements:
+The ``u_hill_coefficient`` is used as follows:
 
-- `gsynSRSF`, the scale factor for the conductance; `SRSF`: 'synaptic receptor scaling factor'
-- `uHillCoefficient`, a coefficient describing the scaling of `u` to be
-  done by the simulator:
+.. math::
 
-  .. math::
+   u_\text{final} = u \cdot y \cdot \frac{ca^4}{u_\text{Hill}^4 + ca^4}
 
-     u_\text{final} = u \cdot y \cdot \frac{ca^4}{u_\text{Hill}^4 + ca^4}
-
-  where :math:`ca` denotes the simulated calcium concentration in
-  millimolar and :math:`y` a scalar such that at
-  :math:`ca = 2.0:\ u_\text{final} = u`. (Markram et al., 2015)
+where :math:`ca` denotes the simulated calcium concentration in millimolar and :math:`y` a
+scalar such that at :math:`ca = 2.0:\ u_\text{final} = u`. (Markram et al., 2015)
 
 These attributes will be copied for each synapse corresponding to its
 classification.  If they are not specified, no corresponding columns will

--- a/source/recipe.rst
+++ b/source/recipe.rst
@@ -28,8 +28,8 @@ example or a TouchDetector configuration may look like:
 Generic pathway selection
 -------------------------
 
-One can create rules that only apply to certain ``pathways``.
-synapses they apply to by restricting attributes of source and target node populations.
+One can create rules that only apply to certain "pathways" by restricting attributes of
+source and target node populations.
 As such, the rules have properties that are prefixed with `src_` to match attributes from
 the source node population, and likewise prefixed with `dst_` to match target node
 population attributes.  All attributes are described in :ref:`node_file`, the currently
@@ -40,7 +40,9 @@ supported ones are:
 - ``region``
 - ``synapse_class``
 
-All supported attributes support the use of simple wild cards.  The following rule matches all synapses connecting cells of MType starting with ``L6_`` to ones with MType ``L1_PYR``, from any source region to the target region ``SPYR``:
+All supported attributes support the use of simple wild cards.  The following rule matches
+all synapses connecting cells of MType starting with ``L6_`` to ones with MType
+``L1_PYR``, from any source region to the target region ``SPYR``:
 
 .. code:: yaml
 

--- a/source/recipe.rst
+++ b/source/recipe.rst
@@ -104,21 +104,6 @@ Distances used when transforming touch regions into synapse candidates.
    ``region_gap``                  Mandatory   The maximum distance between two touch regions at which they are merged.
    =============================== =========== ===
 
-``circuit``
-^^^^^^^^^^^
-
-*Required* by Functionalizer when using Pandas DataFrames.
-
-.. table::
-
-   =============================== =========== ===
-   Property                        Requirement Description
-   =============================== =========== ===
-   configuration_file              Mandatory   The circuit configuration file to use.
-   source_population               Mandatory   Source node population to use.
-   target_population               Mandatory   Target node population to use.
-   =============================== =========== ===
-
 ``connection_rules``
 ^^^^^^^^^^^^^^^^^^^^
 
@@ -221,15 +206,19 @@ selection attributes, the following parameters may be present:
    ==================================== =========== ===
    Property                             Requirement Description
    ==================================== =========== ===
-   ``type``                             Mandatory   A name that will be referenced by ``properties``.  It has to start with either ``E`` for excitatory connections or ``I`` for inhibitory connections.
+   ``class``                            Mandatory   A name that will be referenced by ``properties``.  It has to start with either ``E`` for excitatory connections or ``I`` for inhibitory connections.
    ``neural_transmitter_release_delay`` Optional    Defaults to 0.1 ms
    ``axonal_conduction_velocity``       Optional    Defaults to 300 μm/ms
    ==================================== =========== ===
 
-``properties``
-~~~~~~~~~~~~~~
+Please note that contrary to the legacy XML recipe, precedence is handled very strict:
+later rules always override earlier ones.  There is no special treatment for more general
+rules to not override more specialized ones.
 
-Here, the ``type`` field has to match a ``type`` value of the
+``classes``
+~~~~~~~~~~~
+
+Here, the ``class`` field has to match a ``class`` value of the
 ``rules``. The properties are assigned using the following
 random number distributions, using a mean `m` and standard deviation `sd`:
 
@@ -293,13 +282,16 @@ be created in the output.
    =============================== =========== ===
    ``src_mtype``                   Mandatory   The MType of the source cell.
    ``dst_mtype``                   Mandatory   The MType of the target cell.
-   ``type``                        Mandatory   Has to be ``AIS``.
+   ``class``                       Mandatory   Has to be ``AIS``.
    =============================== =========== ===
 
 ``touch_rules``
 ^^^^^^^^^^^^^^^
 
 *Optional*, used by Functionalizer.
+
+Determines which touches are allowed, depending on source and target node population
+MType, as well the section type on either the source or target side of the touch.
 
 .. table::
 
@@ -310,4 +302,24 @@ be created in the output.
    ``dst_mtype``                   Mandatory   The MType of the target cell.
    ``afferent_section_type``       Optional    The section type of the target cell
    ``efferent_section_type``       Optional    The section type of the source cell.
+   =============================== =========== ===
+
+The ``afferent_section_type`` and ``efferent_section_type`` may take the values ``soma``,
+``axon``, ``apical``, and ``basal``.  A special value ``dendrite`` may be used to signify
+both ``apical`` and ``basal`` types.
+
+``touch_reduction``
+^^^^^^^^^^^^^^^^^^^
+
+*Optional*, used by Functionalizer.
+
+Used to cut touches according to a flat survival rate set by the user.  Affects all
+touches the same way.
+
+.. table::
+
+   =============================== =========== ===
+   Property                        Requirement Description
+   =============================== =========== ===
+   ``survival_rate``               Mandatory   A flat survival probability of touches.
    =============================== =========== ===

--- a/source/recipe.rst
+++ b/source/recipe.rst
@@ -83,8 +83,8 @@ Synapses with less than the specified distance will be removed by Functionalizer
    =============================== =========== ===
    Property                        Requirement Description
    =============================== =========== ===
-   ``excitatory_synapse_distance`` Optional    The minimum distance from the soma for a synapse of post-synaptic excitatory cells. Defaults to 5µm.
-   ``inhibitory_synapse_distance`` Optional    The minimum distance from the soma for a synapse of post-synaptic inhibitory cells. Defaults to 25µm.
+   ``excitatory_synapse_distance`` Optional    The minimum distance from the soma for a synapse of post-synaptic excitatory cells in µm. Defaults to 5µm.
+   ``inhibitory_synapse_distance`` Optional    The minimum distance from the soma for a synapse of post-synaptic inhibitory cells in µm. Defaults to 25µm.
    =============================== =========== ===
 
 ``bouton_interval``
@@ -99,9 +99,9 @@ Distances used when transforming touch regions into synapse candidates.
    =============================== =========== ===
    Property                        Requirement Description
    =============================== =========== ===
-   ``min_distance``                Mandatory   The minimum distance at which two synapse candidates are placed from each other.
-   ``max_distance``                Mandatory   The maximum distance at which two synapse candidates are placed from each other.
-   ``region_gap``                  Mandatory   The maximum distance between two touch regions at which they are merged.
+   ``min_distance``                Mandatory   The minimum distance at which two synapse candidates are placed from each other in µm.
+   ``max_distance``                Mandatory   The maximum distance at which two synapse candidates are placed from each other in µm.
+   ``region_gap``                  Mandatory   The maximum distance between two touch regions at which they are merged in µm.
    =============================== =========== ===
 
 ``connection_rules``
@@ -148,7 +148,7 @@ A global default setting for the conductance produced by Functionalizer.
    =============================== =========== ===
    Property                        Requirement Description
    =============================== =========== ===
-   gsyn                            Optional    The conductance to be used by all synapses. Defaults to 0.2.
+   conductance                     Optional    The conductance to be used by all synapses. Defaults to 0.2.
    =============================== =========== ===
 
 ``seed``
@@ -232,7 +232,7 @@ The same drawn number is reused for all synapses within the same source to
 target cell connection.
 
 The following properties are supported, with the mean specified by the
-property name, and the standard deviation by appending ``SD`` to the
+property name, and the standard deviation by appending ``_sd`` to the
 property name:
 
 .. table::
@@ -240,19 +240,19 @@ property name:
    ==================================== =========== ===
    Property                             Requirement Description
    ==================================== =========== ===
-   ``gsyn``                             Mandatory   The peak conductance (in nS) for a single synaptic contact, following a Gamma distribution.
-   ``gsyn_sd``                          Mandatory   Standard deviation of ``gsyn``.
-   ``d``                                Mandatory   Time constant (in ms) for recovery from depression, following a Gamma distribution.
-   ``d_sd``                             Mandatory   Standard deviation of ``d``.
-   ``f``                                Mandatory   Time constant (in ms) for recovery from facilitation, following a Gamma distribution.
-   ``f_sd``                             Mandatory   Standard deviation of ``f``.
-   ``u``                                Mandatory   Utilization of synaptic efficacy, following a truncated Normal distribution.
-   ``u_sd``                             Mandatory   Standard deviation of ``u``.
-   ``dtc``                              Mandatory   Decay time constant (in ms), following a truncated Normal distribution.
-   ``dtc_sd``                           Mandatory   Standard deviation of ``dtc``.
-   ``nrrp``                             Mandatory   Number of vesicles in readily releasable pool, following a Poisson distribution.
+   ``conductance``                      Mandatory   The peak conductance (in nS) for a single synaptic contact, following a Gamma distribution.
+   ``conductance_sd``                   Mandatory   Standard deviation of ``conductance``.
+   ``depression_time``                  Mandatory   Time constant (in ms) for recovery from depression, following a Gamma distribution.
+   ``depression_time_sd``               Mandatory   Standard deviation of ``depression_time``.
+   ``facilitation_time``                Mandatory   Time constant (in ms) for recovery from facilitation, following a Gamma distribution.
+   ``facilitation_time_sd``             Mandatory   Standard deviation of ``f``.
+   ``u_syn``                            Mandatory   Utilization of synaptic efficacy, following a truncated Normal distribution.
+   ``u_syn_sd``                         Mandatory   Standard deviation of ``u``.
+   ``decay_time``                       Mandatory   Decay time constant (in ms), following a truncated Normal distribution.
+   ``decay_time_sd``                    Mandatory   Standard deviation of ``dtc``.
+   ``n_rrp_vesicles``                   Mandatory   Number of vesicles in readily releasable pool, following a Poisson distribution.
 
-   ``gsyn_srsf``                        Optional    The scale factor for the conductance; `SRSF`: 'synaptic receptor scaling factor'.
+   ``conductance_scale_factor``         Optional    The scale factor for the conductance; `SRSF`: 'synaptic receptor scaling factor'.
    ``u_hill_coefficient``               Optional    A coefficient describing the scaling of `u` to be done by the simulator.
    ==================================== =========== ===
 


### PR DESCRIPTION
This variation of the recipe will allow to store larger parts in Pandas DataFrames to conserve disk space.

Elements of the XML recipe have been translated to JSON and/or YAML, with a few adjustments for consistency. A converter between the XML recipe and the JSON variant is provided by our internal `fz-td-recipe` package.