### PR TITLE
SimConfig: preserve the order of modifications

### DIFF
--- a/source/sonata_simulation.rst
+++ b/source/sonata_simulation.rst
@@ -145,7 +145,7 @@ Parameters defining global experimental conditions.
    randomize_gaba_rise_time        boolean    Optional    When true, enable legacy behavior to randomize the GABA_A rise time in the helper functions. Default is false which will use a prescribed value for GABA_A rise time.
    mechanisms                                 Optional    Properties to assign values to variables in synapse MOD files.
                                                           The format is a dictionary with keys being the SUFFIX names of MOD files (unique names of mechanisms) and values being dictionaries of variable names in the MOD files and their values. Read about `NMODL2 SUFFIX description here <https://nrn.readthedocs.io/en/8.2.0/hoc/modelspec/programmatic/mechanisms/nmodl2.html#suffix>`_.
-   modifications                              Optional    Dictionary of dictionaries with each member describing a modification that mimics experimental manipulations to the circuit.
+   modifications                              Optional    List of dictionaries with each member describing a modification that mimics experimental manipulations to the circuit. They are executed in the order as being read from the file.
    =============================== ========== =========== ====================================
 
 Parameters required for modifications
@@ -155,11 +155,12 @@ Parameters required for modifications
    =============================== ========== =========== ====================================
    property                        Type       Requirement Description
    =============================== ========== =========== ====================================
-   node_set                        string     Mandatory   Node set which receives the manipulation.
-   type                            string     Mandatory   Name of the manipulation. Supported values are "TTX" and "ConfigureAllSections".
+   name                            text       Mandatory   Descriptive name for the modification.
+   node_set                        text       Mandatory   Node set which receives the manipulation.
+   type                            text       Mandatory   Name of the manipulation. Supported values are "TTX" and "ConfigureAllSections".
                                                           "TTX" mimics the application of tetrodotoxin, which blocks sodium channels and precludes spiking.
                                                           "ConfigureAllSections" is a generic way to modify variables (properties, mechanisms, etc.) per morphology section.
-   section_configure               string     Mandatory*  For "ConfigureAllSections" manipulation, a snippet of python code to perform one or more assignments involving section attributes, for all sections that have all the referenced attributes.
+   section_configure               text       Mandatory*  For "ConfigureAllSections" manipulation, a snippet of python code to perform one or more assignments involving section attributes, for all sections that have all the referenced attributes.
                                                           The wildcard %s represents each section. Multiple statements are separated by semicolons. E.g., "%s.attr = value; %s.attr2 \*= value2".
    =============================== ========== =========== ====================================
 
@@ -181,17 +182,19 @@ example::
                "property_z": "string"
            }
        },
-       "modifications": {
-           "applyTTX": {
+       "modifications": [
+           {
+               "name": "applyTTX",
                "node_set": "single",
                "type": "TTX"
            },
-           "no_SK_E2": {
+           {
+               "name": "no_SK_E2",
                "node_set": "single",
                "type": "ConfigureAllSections",
                "section_configure": "%s.gSK_E2bar_SK_E2 = 0"
            }
-       }
+       ]
   }
 
 inputs


### PR DESCRIPTION
The `modifications` section should be similar to `connection_overrides` that they are applied in the order as being read from the config file. This PR aims to change the data struct of this section from dictionary to list in order to preserve the order. 
